### PR TITLE
Permit client-side JavaScript to take over after server-side rendering.

### DIFF
--- a/src/Sitecore.React/Mvc/JsxView.cs
+++ b/src/Sitecore.React/Mvc/JsxView.cs
@@ -97,6 +97,9 @@ namespace Sitecore.React.Mvc
 
 			IReactComponent reactComponent = this.Environment.CreateComponent(componentName, props);
 			writer.WriteLine(reactComponent.RenderHtml());
+			writer.Write("<script>");
+			writer.Write(reactComponent.RenderJavaScript());
+			writer.WriteLine("</script>");
 		}
 
 		private IReactEnvironment Environment


### PR DESCRIPTION
When React uses server-side rendering, it delivers the raw HTML to the client browser. However, the client browser is still responsible for attaching any necessary event handlers. To accomplish this with ReactJS.NET, it is necessary to call `reactComponent.RenderJavaScript()`, which returns the necessary script that hooks up the client-side events.

See https://reactjs.net/guides/server-side-rendering.html, which talks about an HTML helper named `@Html.ReactInitJavaScript()`.  Although this helper renders the init scripts for all components at once, this pull request instead renders them on a component-by-component basis.