### PR TITLE
Component Name should not have "." , as in JS engine its treated as s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ public SampleReactController : Controller
 ```
 
 - Create your Jsx component
+
+<span style="color:#238567">It's requried to have **Components_** prefix as in the code component it created with name **Components__{ComponentName}**</span>
+
 ```javascript
-var SampleReactRendering = React.createClass({
+var Components_SampleReactRendering = React.createClass({
     render: function() {
         return (
             <div>

--- a/src/Sitecore.React/Mvc/JsxView.cs
+++ b/src/Sitecore.React/Mvc/JsxView.cs
@@ -96,7 +96,7 @@ namespace Sitecore.React.Mvc
 			var componentName = Path.GetFileNameWithoutExtension(this.ViewPath)?.Replace("-", string.Empty);
 			var props = this.GetProps(viewContext.ViewData.Model, placeholderKeys);
 
-		    IReactComponent reactComponent = this.Environment.CreateComponent($"Components.{componentName}", props);
+		    IReactComponent reactComponent = this.Environment.CreateComponent($"Components_{componentName}", props);
 		    if (ReactSettingsProvider.Current.EnableClientside)
 		    {
 		        writer.WriteLine(reactComponent.RenderHtml());


### PR DESCRIPTION
…eparate object. Components.SampleReactRendering will throw error as we don't have an object with name Components.

Component should have name like Components_SampleReactRendering As in the code we are adding "Components" to actual name.
Else to keep it simple just use "ComponentName" with out prefix.