### PR TITLE
Feature/experience editor fixes

### DIFF
--- a/src/Sitecore.React/App_Config/Include/Sitecore.React/Sitecore.React.config
+++ b/src/Sitecore.React/App_Config/Include/Sitecore.React/Sitecore.React.config
@@ -22,7 +22,14 @@
               they are interactive on the page. When false, they are only rendered serverside.
               -->
             <EnableClientside>true</EnableClientside>
-            <!--
+             
+           <!--
+              When true, the react components will have client side JS disabled to avoid errors in Experience Editor.
+              If EnableClientside is false this setting is not needed.
+              -->
+            <DisableClientSideWhenEditing>true</DisableClientSideWhenEditing>
+
+          <!--
               Sets when the bundling will happen:
               Valid options are:
                 runtime:    The react components are generated and bundled on each page load. Each page will have a unique 

--- a/src/Sitecore.React/Configuration/IReactSettings.cs
+++ b/src/Sitecore.React/Configuration/IReactSettings.cs
@@ -6,6 +6,7 @@
         string DynamicPlaceholderType { get; set; }
         string BundleName { get; set; }
         bool EnableClientside { get; set; }
+        bool DisableClientSideWhenEditing { get; set; }
         string BundleType { get; set; }
         string ServerScript { get; set; }
         string ClientScript { get; set; }

--- a/src/Sitecore.React/Configuration/ReactSettings.cs
+++ b/src/Sitecore.React/Configuration/ReactSettings.cs
@@ -6,6 +6,7 @@
         public string DynamicPlaceholderType { get; set; }
         public string BundleName { get; set; }
         public bool EnableClientside { get; set; }
+        public bool DisableClientSideWhenEditing { get; set; }
         public string BundleType { get; set; }
         public string ServerScript { get; set; }
         public string ClientScript { get; set; }

--- a/src/Sitecore.React/Mvc/JsxView.cs
+++ b/src/Sitecore.React/Mvc/JsxView.cs
@@ -97,7 +97,8 @@ namespace Sitecore.React.Mvc
 			var props = this.GetProps(viewContext.ViewData.Model, placeholderKeys);
 
 		    IReactComponent reactComponent = this.Environment.CreateComponent($"Components.{componentName}", props);
-		    if (ReactSettingsProvider.Current.EnableClientside)
+            bool isEditingOverrideEnabled = ReactSettingsProvider.Current.DisableClientSideWhenEditing && Sitecore.Context.PageMode.IsExperienceEditorEditing;
+            if (ReactSettingsProvider.Current.EnableClientside && !isEditingOverrideEnabled)
 		    {
 		        writer.WriteLine(reactComponent.RenderHtml());
 

--- a/src/Sitecore.React/Properties/AssemblyInfo.cs
+++ b/src/Sitecore.React/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("100.0.0.2")]
-[assembly: AssemblyFileVersion("100.0.0.2")]
+[assembly: AssemblyVersion("2.0.0.1")]
+[assembly: AssemblyFileVersion("2.0.0.1")]

--- a/src/Sitecore.React/Properties/AssemblyInfo.cs
+++ b/src/Sitecore.React/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("100.0.0.2")]
+[assembly: AssemblyFileVersion("100.0.0.2")]


### PR DESCRIPTION
I need client side React to be supported on the front end, however in Experience Editor this breaks thing. 

Provides a way to disable client side scripting when editing. 