### PR TITLE
Ability to turn off client side script in Editing mode

### DIFF
--- a/src/Sitecore.React/App_Config/Include/Sitecore.React/Sitecore.React.config
+++ b/src/Sitecore.React/App_Config/Include/Sitecore.React/Sitecore.React.config
@@ -22,7 +22,14 @@
               they are interactive on the page. When false, they are only rendered serverside.
               -->
             <EnableClientside>true</EnableClientside>
-            <!--
+             
+           <!--
+              When true, the react components will have client side JS disabled to avoid errors in Experience Editor.
+              If EnableClientside is false this setting is not needed.
+              -->
+            <DisableClientSideWhenEditing>true</DisableClientSideWhenEditing>
+
+          <!--
               Sets when the bundling will happen:
               Valid options are:
                 runtime:    The react components are generated and bundled on each page load. Each page will have a unique 

--- a/src/Sitecore.React/Configuration/IReactSettings.cs
+++ b/src/Sitecore.React/Configuration/IReactSettings.cs
@@ -6,6 +6,7 @@
         string DynamicPlaceholderType { get; set; }
         string BundleName { get; set; }
         bool EnableClientside { get; set; }
+        bool DisableClientSideWhenEditing { get; set; }
         string BundleType { get; set; }
         string ServerScript { get; set; }
         string ClientScript { get; set; }

--- a/src/Sitecore.React/Configuration/ReactSettings.cs
+++ b/src/Sitecore.React/Configuration/ReactSettings.cs
@@ -6,6 +6,7 @@
         public string DynamicPlaceholderType { get; set; }
         public string BundleName { get; set; }
         public bool EnableClientside { get; set; }
+        public bool DisableClientSideWhenEditing { get; set; }
         public string BundleType { get; set; }
         public string ServerScript { get; set; }
         public string ClientScript { get; set; }

--- a/src/Sitecore.React/Mvc/JsxView.cs
+++ b/src/Sitecore.React/Mvc/JsxView.cs
@@ -97,7 +97,8 @@ namespace Sitecore.React.Mvc
 			var props = this.GetProps(viewContext.ViewData.Model, placeholderKeys);
 
 		    IReactComponent reactComponent = this.Environment.CreateComponent($"Components.{componentName}", props);
-		    if (ReactSettingsProvider.Current.EnableClientside)
+            bool isEditingOverrideEnabled = ReactSettingsProvider.Current.DisableClientSideWhenEditing && Sitecore.Context.PageMode.IsExperienceEditorEditing;
+            if (ReactSettingsProvider.Current.EnableClientside && !isEditingOverrideEnabled)
 		    {
 		        writer.WriteLine(reactComponent.RenderHtml());
 


### PR DESCRIPTION
Another pull request solved this issue for me:
_registerComponent(...): Target container is not a DOM element.

However I still need client side script to work when not in Experience Editor. 

This adds the ability to turn off client side script only when editing in Experience Editor to solve. 